### PR TITLE
New logic for selecting template

### DIFF
--- a/fpo-api/api/views_old.py
+++ b/fpo-api/api/views_old.py
@@ -89,8 +89,8 @@ class SurveyPdfView(generics.GenericAPIView):
         tpl_name = "survey-{}.html".format(name)
         # return HttpResponseBadRequest('Unknown survey name')
 
-        #responses = json.loads(request.POST["data"])
-        responses = {'question1': 'test value'}
+        responses = json.loads(request.POST["data"])
+        # responses = {'question1': 'test value'}
 
         template = get_template(tpl_name)
         html_content = template.render(responses)

--- a/fpo-api/templates/notice-to-disputant-response.html
+++ b/fpo-api/templates/notice-to-disputant-response.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Family Law Matter Claim</title>
+  <title>Notice to Disputant Response</title>
   <style type="text/css">
     @page {
         size: Letter;

--- a/fpo-api/templates/test.sh
+++ b/fpo-api/templates/test.sh
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-curl -X POST --output notice-to-disputant-response.pdf \
-  -H 'Accept: application/pdf' \
+curl -X POST \
+  -H 'Accept: application/json' \
   -H 'Content-Type: application/json' \
+  --output "output.pdf" \
   -d '@test-data-notice-in-person.json' \
-  "http://localhost:8081/form/?name=notice-to-disputant-response"
+  "http://localhost:8000/api/v1/submit-form/?name=notice-to-disputant-response"
+
+  # "http://localhost:8081/form/?name=notice-to-disputant-response"
 
   # "http://0.0.0.0:8081/form/?name=violation-ticket-statement-and-written-reasons"
 

--- a/fpo-api/templates/update-template.sh
+++ b/fpo-api/templates/update-template.sh
@@ -2,4 +2,3 @@
 /usr/bin/docker cp notice-to-disputant-response.html fpo_fpo-api_1:/opt/app-root/src/templates/
 # /usr/bin/docker cp violation-ticket-statement-and-written-reasons.html fpo_fpo-api_1:/opt/app-root/src/templates/
 
-

--- a/fpo-api/templates/violation-ticket-statement-and-written-reasons.html
+++ b/fpo-api/templates/violation-ticket-statement-and-written-reasons.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Family Law Matter Claim</title>
+  <title>Violation Ticket Statement and Written Reasons</title>
   <style type="text/css">
     @page {
         size: Letter;


### PR DESCRIPTION
I ported over the logic from the `/form` end point to `/v1/submit-form`. This allows you to select the form type via the POST request.
I also fixed the form names within the template.