### PR TITLE
Middleware improvements + proxy.conf.json

### DIFF
--- a/fpo-api/fpo_api/forwarded_middleware.py
+++ b/fpo-api/fpo_api/forwarded_middleware.py
@@ -12,6 +12,7 @@ class XForwardedForPortMiddleware(MiddlewareMixin):
         if (
             "HTTP_X_FORWARDED_HOST" in request.META
             and "HTTP_X_FORWARDED_PORT" in request.META
+            and request.META["HTTP_X_FORWARDED_PORT"] not in ("80", "443")
         ):
             request.META["HTTP_X_FORWARDED_HOST"] = (
                 request.META["HTTP_X_FORWARDED_HOST"]

--- a/fpo-web/src/proxy.conf.json
+++ b/fpo-web/src/proxy.conf.json
@@ -1,11 +1,17 @@
 [
 	{
-    "context": ["/choose-how-to-attend-your-traffic-hearing/api", "/api"],
-    "target": "http://localhost:8081",
-	"pathRewrite": {
-      "^/choose-how-to-attend-your-traffic-hearing/": "/"
-    },
-    "secure": false,
-    "changeOrigin": true
+		"context": [
+			"/choose-how-to-attend-your-traffic-hearing/api",
+			"/api"
+		],
+		"target": "http://localhost:8081",
+		"pathRewrite": {
+			"^/choose-how-to-attend-your-traffic-hearing/": "/"
+		},
+		"secure": false,
+		"changeOrigin": true,
+		"headers": {
+			"X-Forwarded-Host": "localhost:8080"
+		}
 	}
 ]


### PR DESCRIPTION
Add in X-Forwarded-Host for local proxy.conf.json.
Make middle-ware not change the X-Forwarded-For if the port is 80 or 443.