### PR TITLE
Small Auth changes to include KC_IDP_HINT

### DIFF
--- a/fpo-api/api/auth.py
+++ b/fpo-api/api/auth.py
@@ -1,12 +1,12 @@
 import logging
 import random
 import re
+import urllib
 from string import ascii_lowercase, digits
 
 from rest_framework import permissions
 from django.conf import settings
 from django.urls.exceptions import NoReverseMatch
-from django.utils.encoding import escape_uri_path
 
 from rest_framework import authentication
 from rest_framework.request import Request
@@ -21,12 +21,15 @@ from oidc_rp.models import OIDCUser
 def get_login_uri(request: Request = None, next: str = None) -> str:
     uri = None
     if request:
+        query_dictionary = {"next": next, "kc_idp_hint": settings.OIDC_RP_KC_IDP_HINT}
+        query_dictionary = {k: v for k, v in query_dictionary.items() if v is not None}
         try:
-            uri = reverse("oidc_auth_request", request=request)
+            uri = "{base_url}?{querystring}".format(
+                base_url=reverse("oidc_auth_request", request=request),
+                querystring=urllib.parse.urlencode(query_dictionary),
+            )
         except NoReverseMatch:
             pass
-        if uri and next:
-            uri += "?next=" + escape_uri_path(next)
     return uri
 
 

--- a/fpo-api/api/utils.py
+++ b/fpo-api/api/utils.py
@@ -9,28 +9,6 @@ from api.pdf import render as render_pdf
 
 
 def generate_pdf(data):
-
-    # Add date to the payload
-    # today = date.today().strftime('%d-%b-%Y')
-    # data['date'] = today
-
-    #  #######################
-    #  # Notice To Disputant - Response
-    #  #
-    #  # Make the Violation Ticket Number all upper case
-    # try:
-    #     x = data['ticketNumber']['prefix']
-    #     data['ticketNumber']['prefix'] = x.upper()
-    # except KeyError:
-    #     pass
-
-    # # Format the data more user friendly
-    # try:
-    #     x = datetime.strptime(data['ticketDate'],'%Y-%m-%d')
-    #     data['ticketDate'] = x.strftime('%d-%b-%Y')
-    # except KeyError:
-    #     pass
-
     template = "notice-to-disputant-response.html"
     template = get_template(template)
     html_content = template.render(data)

--- a/fpo-api/fpo_api/settings.py
+++ b/fpo-api/fpo_api/settings.py
@@ -227,7 +227,7 @@ if OIDC_RP_PROVIDER_ENDPOINT:
     OIDC_RP_AUTHENTICATION_REDIRECT_URI = (
         os.getenv("OIDC_RP_AUTHENTICATION_REDIRECT_URI", "/choose-how-to-attend-your-traffic-hearing/")
     )
-    OIDC_RP_KC_IDP_HINT = os.getenv("OIDC_RP_KC_IDP_HINT", "idir")
+    OIDC_RP_KC_IDP_HINT = os.getenv("OIDC_RP_KC_IDP_HINT")
 
     DRF_AUTH_CLASS = (
         "oidc_rp.contrib.rest_framework.authentication.BearerTokenAuthentication"

--- a/fpo-api/fpo_api/settings.py
+++ b/fpo-api/fpo_api/settings.py
@@ -227,6 +227,7 @@ if OIDC_RP_PROVIDER_ENDPOINT:
     OIDC_RP_AUTHENTICATION_REDIRECT_URI = (
         os.getenv("OIDC_RP_AUTHENTICATION_REDIRECT_URI", "/choose-how-to-attend-your-traffic-hearing/")
     )
+    OIDC_RP_KC_IDP_HINT = os.getenv("OIDC_RP_KC_IDP_HINT", "idir")
 
     DRF_AUTH_CLASS = (
         "oidc_rp.contrib.rest_framework.authentication.BearerTokenAuthentication"

--- a/fpo-web/src/app/guards/auth-guard.component.ts
+++ b/fpo-web/src/app/guards/auth-guard.component.ts
@@ -34,8 +34,11 @@ export class AuthGuard implements CanActivate {
       let extUri =
         window.location.origin + this.location.prepareExternalUrl(state.url);
       if (extUri.substr(-1) != "/") extUri += "/";
+
+      let url = new URL(userInfo.login_uri);
+      url.searchParams.append("next", extUri); 
       window.location.replace(
-        userInfo.login_uri + "?next=" + encodeURIComponent(extUri)
+        url.toString()
       );
     } else if (userInfo.is_staff) {
       return true;

--- a/fpo-web/src/polyfills.ts
+++ b/fpo-web/src/polyfills.ts
@@ -28,6 +28,8 @@
 /** Evergreen browsers require these. **/
 import 'core-js/es/reflect';
 
+/* Needed for url-search-params. Used in route-guard. */
+import 'core-js/features/url-search-params';
 
 /** ALL Firefox browsers require the following to support `@angular/animation`. **/
 // import 'web-animations-js';  // Run `npm install --save web-animations-js`.

--- a/fpo-web/src/polyfills.ts
+++ b/fpo-web/src/polyfills.ts
@@ -28,7 +28,8 @@
 /** Evergreen browsers require these. **/
 import 'core-js/es/reflect';
 
-/* Needed for url-search-params. Used in route-guard. */
+/** Needed for url-search-params. Used in route-guard. **/
+import 'core-js/features/url';
 import 'core-js/features/url-search-params';
 
 /** ALL Firefox browsers require the following to support `@angular/animation`. **/


### PR DESCRIPTION
Use a query_dictionary for get_login_uri.
Cleanup utils.py.
Add new setting: OIDC_RP_KC_IDP_HINT.
Redo url generation in auth-guard.
Include polyfills for url-search-params - that way inbox page can load in IE 11.