### PR TITLE
Opt admin users out of Matomo stats. This should create a cookie call…

### DIFF
--- a/fpo-web/src/app/admin/admin.component.ts
+++ b/fpo-web/src/app/admin/admin.component.ts
@@ -91,6 +91,8 @@ export class AdminComponent implements OnInit {
   }
 
   ngOnInit() {
+    //Opt admin users out from Matomo stats.
+    (<any>window)._paq.push(['optUserOut']);
     this.loadPage();
     this.outdatedBrowser = this.checkForIEOrOldEdge();
     //Hide footer detail.


### PR DESCRIPTION
…ed "mtm_consent_removed". It's possible to re-opt back in if needed via javascript.